### PR TITLE
Fixed: proper application use

### DIFF
--- a/src/type_checker/env.ml
+++ b/src/type_checker/env.ml
@@ -37,7 +37,6 @@ let rec unify ~pos t1 t2 : unit =
       unify ~pos t11 t21;
       unify ~pos t12 t22
   | Tarrow (t1, _), t2 -> unify ~pos t1 t2
-  | t1, Tarrow (t2, _) -> unify ~pos t1 t2
   | t1, t2 when t1 = t2 -> ()
   | t1, t2 -> Errors.type_error (canon t1) (canon t2) pos
 

--- a/tests/type_checker_test/type_checker_test.ml
+++ b/tests/type_checker_test/type_checker_test.ml
@@ -45,6 +45,15 @@ let%test "wrong_application" =
   | exception Type_checker.Errors.TypeError _ -> true
   | (exception _) | _ -> false
 
+let%test "wrong_application2" =
+  let parsed = Parser.of_string "let f a = a; let _ = 1 f" |> Parser.parse in
+  (* |> List.iter (fun a -> Ast.Parsing.pp_t a |> print_string |> flush_all); *)
+  match
+    Type_checker.type_ast ~env:(Type_checker.Env.empty Runtime.empty) parsed
+  with
+  | exception Type_checker.Errors.TypeError _ -> true
+  | (exception _) | _ -> false
+
 let%expect_test "runtime" =
   Parser.of_string "let _ = printint 15"
   |> Parser.parse

--- a/tests/type_checker_test/type_checker_test.ml
+++ b/tests/type_checker_test/type_checker_test.ml
@@ -36,6 +36,15 @@ let%expect_test "let" =
     let f : 'a -> 'a = [typ 'a -> 'a](fun (a) -> ([typ 'a]a))
     ;let b : int = [typ int](([typ int -> int]f) ([typ int]10));let c : bool = [typ bool](([typ bool -> bool]f) ([typ bool]false)); |}]
 
+let%test "wrong_application" =
+  let parsed = Parser.of_string "let _ = 1 2" |> Parser.parse in
+  (* |> List.iter (fun a -> Ast.Parsing.pp_t a |> print_string |> flush_all); *)
+  match
+    Type_checker.type_ast ~env:(Type_checker.Env.empty Runtime.empty) parsed
+  with
+  | exception Type_checker.Errors.TypeError _ -> true
+  | (exception _) | _ -> false
+
 let%expect_test "runtime" =
   Parser.of_string "let _ = printint 15"
   |> Parser.parse


### PR DESCRIPTION
Improper application use was allowed. For example `1 2` would typecheck.